### PR TITLE
feat: support backbone-only CIF output and parallel-seed dump_dir

### DIFF
--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -32,10 +32,14 @@ def main(configs : DictConfig) -> None:
     print_configs(configs)
     os.environ["DATA_ROOT_DIR"] = configs.data_root_dir
     os.environ["CKPT_ROOT_DIR"] = configs.ckpt_root_dir
+    hydra_output_dir = HydraConfig.get().runtime.output_dir
     configs = ConfigDict(
         OmegaConf.to_container(configs.exp, resolve=True)
     )
-    dump_dir = HydraConfig.get().runtime.output_dir
+    # exp.dump_dir allows the caller to separate data output from hydra's
+    # working directory, which is needed when parallel seed workers each
+    # require a distinct hydra.run.dir but share one output directory.
+    dump_dir = configs.get("dump_dir", None) or hydra_output_dir
     configs.dump_dir = dump_dir
     error_dir = Path(dump_dir) / "errors"
     if DIST_WRAPPER.rank == 0:
@@ -45,7 +49,7 @@ def main(configs : DictConfig) -> None:
     logger.info(
         f"Distributed environment: world size: {DIST_WRAPPER.world_size}, "
         + f"global rank: {DIST_WRAPPER.rank}, local rank: {DIST_WRAPPER.local_rank}"
-    )    
+    )
     device = torch.device("cuda:{}".format(DIST_WRAPPER.local_rank))
     torch.cuda.set_device(device)
     if DIST_WRAPPER.world_size > 1:
@@ -72,7 +76,7 @@ def main(configs : DictConfig) -> None:
     )
 
     infer_runner.run()
-    
+
 
 if __name__ == "__main__":
     main()

--- a/src/utils/inference/dumper.py
+++ b/src/utils/inference/dumper.py
@@ -127,24 +127,24 @@ class DataDumper:
                         new_atom_array,
                         per_chain_edits=per_chain_edits,
                         design_modality=design_modality,
-                    )    
-
-                    output_fpath = os.path.join(
-                        prediction_save_dir,
-                        f"{sample_name}_seed_{seed}_bb_{rank}_seq_{seq_var_idx}.cif",
-                    )                    
-
-                    if b_factor is not None:
-                        # b_factor.shape == [N_sample, N_atom]
-                        new_atom_array.set_annotation("b_factor", np.round(b_factor[idx], 2))
-
-                    save_structure_cif(
-                        atom_array=new_atom_array,
-                        pred_coordinate=pred_coordinates[idx],
-                        output_fpath=output_fpath,
-                        entity_poly_type=entity_poly_type,
-                        pdb_id=sample_name,
                     )
+
+                output_fpath = os.path.join(
+                    prediction_save_dir,
+                    f"{sample_name}_seed_{seed}_bb_{rank}_seq_{seq_var_idx}.cif",
+                )
+
+                if b_factor is not None:
+                    # b_factor.shape == [N_sample, N_atom]
+                    new_atom_array.set_annotation("b_factor", np.round(b_factor[idx], 2))
+
+                save_structure_cif(
+                    atom_array=new_atom_array,
+                    pred_coordinate=pred_coordinates[idx],
+                    output_fpath=output_fpath,
+                    entity_poly_type=entity_poly_type,
+                    pdb_id=sample_name,
+                )
 
     def _apply_sequence_variant_to_atom_array(
         self,


### PR DESCRIPTION
## Summary

Two small fixes to support backbone-only inference pipelines and parallel seed execution:

- **`scripts/inference.py`**: decouple data output directory from Hydra working directory by introducing an optional `exp.dump_dir` config override. When running multiple seeds in parallel, each worker needs its own `hydra.run.dir` to avoid config file conflicts, while all workers should write outputs to a shared directory. Without this change, outputs from different workers overwrite each other. Original behavior (no `dump_dir` set) is unchanged.

- **`src/utils/inference/dumper.py`**: save backbone CIF files even when `use_invfold=false`. Previously, `save_structure_cif()` was inside the `if variant is not None` block, so no CIF was written when inverse folding was skipped. Moving it outside the block ensures backbone structures are always saved, enabling downstream pipelines (e.g. motif scaffolding evaluation) that only need backbone coordinates.

## Compatibility

Both changes are fully backward-compatible. Existing usage without the new parameters is unaffected.

## Test

Validated on MotifBench motif scaffolding tasks with `use_invfold=false` and parallel seed execution across multiple GPUs.